### PR TITLE
Cr 568 add sso to field service

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
@@ -232,11 +232,10 @@ public class CensusFieldSvcApplication {
 
     // Sets the max authentication age to a really large value.
     // This prevents spring boot from deciding that authentication is too old and throwing an
-    // exception. It should
-    // mean that we rely on whatever reauthentication period the IDP uses.
+    // exception. It should mean that we rely on whatever reauthentication period the IDP uses.
     private WebSSOProfileConsumer customWebSSOProfileConsumer() {
       DSLWebSSOProfileConsumerImpl consumer = new DSLWebSSOProfileConsumerImpl();
-      consumer.setMaxAuthenticationAge(3600 * 24 * 365 * 50); // Big, but not bigger than max int
+      consumer.setMaxAuthenticationAge(appConfig.getSso().getSpringMaxAuthenticationAge());
       return consumer;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
@@ -188,13 +188,15 @@ public class CensusFieldSvcApplication {
 
     @Override
     public void configure(ServiceProviderBuilder serviceProvider) throws Exception {
+      SsoConfig ssoConfig = appConfig.getSso();
+
       String idpMetadata = loadIdpMetadata();
       ResourceBackedMetadataProvider idpMetadataProvider =
           new ResourceBackedMetadataProvider(null, new StringResource(idpMetadata));
 
       serviceProvider
           .metadataGenerator()
-          .entityId("localhost")
+          .entityId(ssoConfig.getEntityId())
           .and()
           .sso()
           .and()
@@ -203,7 +205,7 @@ public class CensusFieldSvcApplication {
           .and()
           .metadataManager()
           .metadataProvider(idpMetadataProvider)
-          .defaultIDP("https://accounts.google.com/o/saml2?idpid=C00n4re6c")
+          //.defaultIDP("https://accounts.google.com/o/saml2?idpid=C00n4re6c")
           .refreshCheckInterval(60 * 1000)
           .and()
           .extendedMetadata()
@@ -215,7 +217,6 @@ public class CensusFieldSvcApplication {
           .and()
           .ssoProfileConsumer(customWebSSOProfileConsumer());
 
-      SsoConfig ssoConfig = appConfig.getSso();
       if (ssoConfig.isUseReverseProxy()) {
         ReverseProxyConfig reverseProxyConfig = ssoConfig.getReverseProxy();
         log.info("Using reverseProxy: " + reverseProxyConfig);

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/config/SsoConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/config/SsoConfig.java
@@ -8,5 +8,6 @@ public class SsoConfig {
   private boolean useReverseProxy;
   @NotBlank private String idpId;
   @NotBlank private String metadataCertificate;
+  private long springMaxAuthenticationAge;
   private ReverseProxyConfig reverseProxy;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/config/SsoConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/config/SsoConfig.java
@@ -7,6 +7,7 @@ import lombok.Data;
 public class SsoConfig {
   private boolean useReverseProxy;
   @NotBlank private String idpId;
+  @NotBlank private String entityId;
   @NotBlank private String metadataCertificate;
   private long springMaxAuthenticationAge;
   private ReverseProxyConfig reverseProxy;

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/endpoint/HomeController.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/endpoint/HomeController.java
@@ -12,10 +12,11 @@ public class HomeController {
 
   @RequestMapping("/home")
   public ModelAndView home(
-      @SAMLUser SAMLUserDetails user, @RequestParam(required = false) String pppp) {
+      @SAMLUser SAMLUserDetails user, @RequestParam(required = false) String caseId) {
     ModelAndView homeView = new ModelAndView("home");
     homeView.addObject("userId", user.getUsername());
     homeView.addObject("samlAttributes", user.getAttributes());
+    homeView.addObject("caseId", caseId);
     return homeView;
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -92,6 +92,7 @@ server:
 
 sso:
   useReverseProxy: false
+  entityId: localhost
  
 spring:
   mvc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,7 @@ server:
 sso:
   useReverseProxy: true
   idpId:
+  entityId:
   metadataCertificate:
   springMaxAuthenticationAge: 1211400 # 14 days and half an hour
   reverseProxy:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,7 @@ sso:
   useReverseProxy: true
   idpId:
   metadataCertificate:
+  springMaxAuthenticationAge: 1211400 # 14 days and half an hour
   reverseProxy:
     scheme: http
     contextPath: /

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -8,6 +8,7 @@
 <h1>This is the Home Page</h1>
 
 <h2>Current User: <span th:text="${userId}">unknown</span></h2>
+<h2>Case ID: <span th:text="${caseId}">unknown</span></h2>
 <table title="SAML Attributes" border="1">
     <thead>
     <tr>


### PR DESCRIPTION
Entity id now set through configuration instead of incorrectly being hard coded to 'localhost'.
Set 'sso.entityId'.

Home endpoint now takes a 'caseId' query parameter.