### PR TITLE
change server port number from 8443 to 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ To run the census-field-service you can run CensusFieldSvcApplication with the f
 
 ### Endpoints and pages
 
-LaunchEQ: https://localhost:8443/launch/47066415-b59f-4df1-869b-8e2b4e818e82
+LaunchEQ: https://localhost:443/launch/47066415-b59f-4df1-869b-8e2b4e818e82
 
-An unprotected field service page: https://localhost:8443/completed
+An unprotected field service page: https://localhost:443/completed
 
 ### HTTPS & SSL keystore
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ logging:
 domain: localhost
 
 server:
-  port: 8443
+  port: 443
   ssl:  # Enable ssl, as the G Suite IDP will only work with a https SAML endpoint
     key-store: classpath:localhost-ssl-keystore.p12
     key-store-password: cfsstore-pw
@@ -20,4 +20,4 @@ server:
 sso:
   useReverseProxy: false
   entityId: ${domain}
-  entityBaseURL: https://${domain}:8443
+  entityBaseURL: https://${domain}:443


### PR DESCRIPTION
Change port number from 8443 to 443 so that the same port number (443) will be used whether running the field service locally or in one of the Google Cloud kubernetes environments.