### PR TITLE
Cr-623 Spring SAML session issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,25 +44,10 @@
       </exclusions>
     </dependency>
 
-<!-- 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
-
-      <exclusions>
-        <exclusion>
-          <groupId>redis.clients</groupId>
-          <artifactId>jedis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>biz.paluch.redis</groupId>
-      <artifactId>lettuce</artifactId>
-      <version>3.4.2.Final</version>
-    </dependency>
-    -->
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
 
-	<dependency>
-		<groupId>org.springframework.session</groupId>
-		<artifactId>spring-session-data-redis</artifactId>
+    <dependency>
+	  <groupId>org.springframework.session</groupId>
+	  <artifactId>spring-session-data-redis</artifactId>
 	</dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.integration</groupId>
     <artifactId>census-int-common-config</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.0.14</version>
   </parent>
 
   <name>Census Field Service</name>
@@ -82,6 +82,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.integration</groupId>
     <artifactId>census-int-common-config</artifactId>
-    <version>0.0.14</version>
+    <version>0.0.15-SNAPSHOT</version>
   </parent>
 
   <name>Census Field Service</name>
@@ -49,6 +49,11 @@
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
 
+	<dependency>
+		<groupId>org.springframework.session</groupId>
+		<artifactId>spring-session-data-redis</artifactId>
+	</dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
@@ -77,7 +82,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
@@ -34,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.saml.websso.WebSSOProfileConsumer;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -243,26 +244,16 @@ public class CensusFieldSvcApplication {
       }
     }
 
-    //    @Bean
-    //    RedisConnectionFactory redisConnectionFactory() {
-    //      return new LettuceConnectionFactory();
-    //    }
-    //
-    //    @Bean
-    //    public RedisTemplate<String, Session> sessionRedisTemplate(
-    //        RedisConnectionFactory connectionFactory) {
-    //
-    //      RedisTemplate<String, Session> template = new RedisTemplate<String, Session>();
-    //      template.setKeySerializer(new StringRedisSerializer());
-    //      template.setHashKeySerializer(new StringRedisSerializer());
-    //
-    //      // JSON Serializer for HashValues
-    //      template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
-    //
-    //      template.setConnectionFactory(connectionFactory);
-    //
-    //      return template;
-    //    }
+    /**
+     * Spring-session tries to use the Redis Config command during initialisation.
+     * Hosted Redis services disable this command and during startup you get the error:
+     *     RedisCommandExecutionException: ERR unknown command `CONFIG`
+     * Bean disables automatic configuration of Redis.
+     */
+    @Bean
+    ConfigureRedisAction configureRedisAction() {
+      return ConfigureRedisAction.NO_OP;
+    }
 
     // Sets the max authentication age to a really large value.
     // This prevents spring boot from deciding that authentication is too old and throwing an

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
@@ -245,10 +245,10 @@ public class CensusFieldSvcApplication {
     }
 
     /**
-     * Spring-session tries to use the Redis Config command during initialisation.
-     * Hosted Redis services disable this command and during startup you get the error:
-     *     RedisCommandExecutionException: ERR unknown command `CONFIG`
-     * Bean disables automatic configuration of Redis.
+     * Spring-session tries to use the Redis Config command during initialisation. Hosted Redis
+     * services disable this command and during startup you get the error:
+     * RedisCommandExecutionException: ERR unknown command `CONFIG` Bean disables automatic
+     * configuration of Redis.
      */
     @Bean
     ConfigureRedisAction configureRedisAction() {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: DEBUG
     uk.gov.ons.ctp.common: INFO
     org.springframework: WARN
-    org.springframework.security: DEBUG
+    org.springframework.security.saml: WARN
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: CLOUD

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: DEBUG
     uk.gov.ons.ctp.common: INFO
     org.springframework: WARN
-    org.springframework.security.saml: WARN
+    org.springframework.security: DEBUG
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: CLOUD

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: INFO
     uk.gov.ons.ctp.common: INFO
     org.springframework: INFO
-    org.springframework.security: DEBUG
+    org.springframework.security.saml: INFO
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: DEV

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: INFO
     uk.gov.ons.ctp.common: INFO
     org.springframework: INFO
-    org.springframework.security.saml: INFO
+    org.springframework.security.saml: WARN
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: DEV

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: INFO
     uk.gov.ons.ctp.common: INFO
     org.springframework: INFO
-    org.springframework.security.saml: WARN
+    org.springframework.security.saml: INFO
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: DEV

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ logging:
     uk.gov.ons.ctp.integration.censusfieldsvc: INFO
     uk.gov.ons.ctp.common: INFO
     org.springframework: INFO
-    org.springframework.security.saml: INFO
+    org.springframework.security: DEBUG
     com.github.ulisesbocchio: INFO
     PROTOCOL_MESSAGE: DEBUG
   profile: DEV
@@ -88,6 +88,9 @@ domain:
 server:
   port: 8177
   use-forward-headers: true  # needed for SAML/SSO to work with a load balancer !
+  servlet:
+    session:
+      timeout: 5m
 
 sso:
   useReverseProxy: true
@@ -107,7 +110,7 @@ sso:
 spring:
   session:
     store-type: redis
-    timeout: 5m
+    timeout: 300
   redis:
     host: 10.254.0.3
     port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,11 +105,12 @@ sso:
     includeServerPortInRequestURL: false
 
 spring:
-#  session:
-#    store-type: redis
-#  redis:
-#    host: localhost
-#    port: 6379
+  session:
+    store-type: redis
+    timeout: 5m
+  redis:
+    host: 10.254.0.3
+    port: 6379
   mvc:
     servlet:
       path: /

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,8 +112,8 @@ spring:
     store-type: redis
     timeout: 300
   redis:
-    host: 10.254.0.3
-    port: 6379
+    host: localhost
+    port: 7379
   mvc:
     servlet:
       path: /


### PR DESCRIPTION
# Motivation and Context
SAML authentication using Spring uses the HTTP session object to store information. With multiple pods running, the round robin load balancing results in an error on authentication. This is as after redirection to the Identity Provider for authentication, when authenticated and redirected back to the Service Provider the client may be routed to another Pod and the client HTTP session will not be available. Due to this behaviour the Field service cannot at present scale and is restricted to one pod.

# What has changed
Spring Session backed by Redis has been used. This adds a SessionRepositoryFilter bean in the Filter chain to wrap HTTPSession and store it in Redis where it is available to all running instances of Field service. This is auto configured for us by Spring Boot by simply adding the required dependencies to the POM and adding a few simple properties.

A couple of further configuration items are required:

- Spring-session tries to auto configure the Redis service during initialisation with use of the Config command. This command is disabled by hosted services and this behaviour must be turned off.

- Spring-session sets the session cookie SameSite attribute to Lax which breaks Spring Security SAML login. Exposing the Spring Session DefaultCookieSerializer allows customisation of Spring Session cookie handling. Setting the sameSite attribute to an empty string results in the SameSite attribute not being set on the session cookie. 

# How to test?
Code deployed to  census-integration-dev with three field service pods running. URL, username and password for issuing a request available from me,  Phil, Peter.