### PR TITLE
CR-770 Field Service to pass formType to EQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.20</version>
+      <version>0.0.23</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.5</version>
+      <version>0.0.11</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImpl.java
@@ -86,6 +86,7 @@ public class LauncherServiceImpl implements LauncherService {
               caseDetails,
               userId,
               questionnaireIdDto.getQuestionnaireId(),
+              questionnaireIdDto.getFormType(),
               accountServiceUrl,
               accountServiceLogoutUrl,
               appConfig.getKeystore());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,7 +112,7 @@ spring:
     store-type: redis
     timeout: 300
   redis:
-    host: 10.254.0.3
+    host: localhost
     port: 6379
   mvc:
     servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,8 +112,8 @@ spring:
     store-type: redis
     timeout: 300
   redis:
-    host: localhost
-    port: 7379
+    host: 10.254.0.3
+    port: 6379
   mvc:
     servlet:
       path: /


### PR DESCRIPTION
# Motivation and Context
Formtype is hard coded when the Field service calls EQ. It is now to be provided by the RM case-api service and passed to EQ by the Field service launch endpoint. 

# What has changed
Now uses version 0.0.11 of census-int-case-api-client. QuestionnaireIdDTO with formType attribute added returned by request to Case service for re-usable questionnaireId.
Updated to version 0.0.23 of eq-launcher to enable passing of formType to EQ. 

# How to test?
Has been tested running locally. Has been deployed and tested in census-integration-dev.

# Links
https://github.com/ONSdigital/census-int-case-api-client/pull/10
https://github.com/ONSdigital/census-mock-case-api-service/pull/17