### PR TITLE
CR-875 Use and configure Undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,8 @@ domain:
 
 server:
   port: 8177
+  undertow.worker-threads: 40
+  undertow.io-threads: 6
   use-forward-headers: true  # needed for SAML/SSO to work with a load balancer !
   servlet:
     session:


### PR DESCRIPTION
# Motivation and Context
Due to a serious threading bug with Jetty RHSVC we have decided to switch from Jetty to Undertow.
We considered using Tomcat but Undertow was able to service more requests from the same hardware so we went with that.

# What has changed
Pom updated to use undertow, and corresponding Undertow thread configuration added to the application.yml file.

# How to test?
This should be a purely internal change. Run the usual tests.