### PR TITLE
CR-991 update/correct out-of-date spring boot properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ To run the census-field-service you can run CensusFieldSvcApplication with the f
     -Dspring.profiles.active=local
     -Dsso.idpId=C00n4re6c 
     -Dsso.metadataCertificate=MIIDdD....
+    
+The above "MIIDdD..." needs to be replaced with a (rather long) valid certificate string.    
 
 ### Endpoints and pages
 
-LaunchEQ: https://localhost:443/launch/47066415-b59f-4df1-869b-8e2b4e818e82
+LaunchEQ: https://localhost:443/launch/3305e937-6fb1-4ce1-9d4c-077f147789ab
 
-An unprotected field service page: https://localhost:443/completed
+An unprotected field service page: https://localhost:443/questionnaireCompleted
 
 ### HTTPS & SSL keystore
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,11 +87,12 @@ domain:
 
 server:
   port: 8177
-  undertow.worker-threads: 40
-  undertow.io-threads: 6
-  use-forward-headers: true  # needed for SAML/SSO to work with a load balancer !
-  shutdown:
-    grace-period: 30s
+  shutdown: graceful
+  undertow:
+    threads:
+      worker: 40
+      io: 6  
+  forward-headers-strategy: NATIVE  # needed for SAML/SSO to work with a load balancer !
   servlet:
     session:
       timeout: 5m
@@ -126,6 +127,8 @@ spring:
       enabled: never
   application:
     name: ONS CensusFieldService
+  lifecycle:
+    timeout-per-shutdown-phase: 30s    
 
 case-service-settings:
   rest-client-config:


### PR DESCRIPTION
Some Spring boot properties have gone out of date, as spotted by @philwhiles .
This updates those properties, in particular the undertow and graceful shutdown properties (which sneakily changed between Spring Boot 2.3.0-RC1 and 2.3.0-RELEASE1).

Also, the "forwarding-header-strategy" is a change. This has been tested locally and on a multi-pod DEV environment manually with the /launch endpoint. This got through to the 404 as expected.

I have also tweaked the README slightly since some of the advice from running locally was out-of-date.