### PR TITLE
CR-1065 use latest event publisher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
       <version>0.0.17</version>
     </dependency>
 
+    <dependency>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>event-publisher</artifactId>
+      <version>0.0.43</version>
+    </dependency>
+
     <!-- ONS END -->
 
     <!-- third party libraries -->


### PR DESCRIPTION
Just a pom update.  

Ensure the latest version of event publisher is used, so there is no chance that out-of-date event structures are stored in firestore.