### PR TITLE
Cr 1557 fix with gsuite

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/CensusFieldSvcApplication.java
@@ -12,6 +12,7 @@ import org.opensaml.saml2.metadata.provider.ResourceBackedMetadataProvider;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -177,6 +178,19 @@ public class CensusFieldSvcApplication {
     template.setExchange("events");
     template.setChannelTransacted(true);
     return template;
+  }
+
+  @Bean
+  public SmartInitializingSingleton appInit(RabbitTemplate rabbitTemplate) {
+    return () -> {
+      try {
+        rabbitTemplate.execute(
+            (channel) -> channel.getConnection().getServerProperties().get("version").toString());
+        log.info("Rabbit connection check success");
+      } catch (Exception e) {
+        log.error("Cannot connect to rabbit; please check configured credentials", e);
+      }
+    };
   }
 
   // Tell Thymeleaf about the supported HTML pages

--- a/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImpl.java
@@ -99,7 +99,7 @@ public class LauncherServiceImpl implements LauncherService {
       throw new FieldServiceException(Fault.SYSTEM_ERROR);
     }
 
-    String eqUrl = "https://" + appConfig.getEq().getHost() + "/session?token=" + encryptedPayload;
+    String eqUrl = "https://" + appConfig.getEq().getHost() + "?token=" + encryptedPayload;
     log.with(eqUrl).debug("EQ URL");
 
     LaunchDetails launchDetails = new LaunchDetails();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -40,6 +40,7 @@ saml:
   sso:
     metadata-generator:
       entity-id: fstestdev
+      entity-base-url: https://${domain}:443
     key-manager:
       private-key-der-location: classpath:/alternate-idp/fstest.key.der
       public-key-pem-location: classpath:/alternate-idp/fstest.pem

--- a/src/main/resources/application-local-with-alt-idp.yml
+++ b/src/main/resources/application-local-with-alt-idp.yml
@@ -53,7 +53,7 @@ saml:
   sso:
     metadata-generator:
       entity-id: fstest
-      entity-base-url: https://${domain}:443  
+      entity-base-url: https://${domain}:443
     key-manager:
       private-key-der-location: classpath:/alternate-idp/fstest.key.der
       public-key-pem-location: classpath:/alternate-idp/fstest.pem

--- a/src/main/resources/application-local-with-alt-idp.yml
+++ b/src/main/resources/application-local-with-alt-idp.yml
@@ -52,9 +52,9 @@ sso:
 saml:
   sso:
     metadata-generator:
-      entity-id: fstest  
+      entity-id: fstest
+      entity-base-url: https://${domain}:443  
     key-manager:
       private-key-der-location: classpath:/alternate-idp/fstest.key.der
       public-key-pem-location: classpath:/alternate-idp/fstest.pem
-  
   

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,8 @@ server:
 
 sso:
   useReverseProxy: false
+
+saml:
+  sso:
+    metadata-generator:
+      entity-base-url: https://${domain}:443  

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,4 +27,4 @@ sso:
 saml:
   sso:
     metadata-generator:
-      entity-base-url: https://${domain}:443  
+      entity-base-url: https://${domain}:443

--- a/src/main/resources/application-testing.yml
+++ b/src/main/resources/application-testing.yml
@@ -40,6 +40,7 @@ saml:
   sso:
     metadata-generator:
       entity-id: fstesttest
+      entity-base-url: https://${domain}:443
     key-manager:
       private-key-der-location: classpath:/alternate-idp/fstest.key.der
       public-key-pem-location: classpath:/alternate-idp/fstest.pem

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,7 +116,7 @@ sso:
 saml:
   sso:
     metadata-generator:
-      entity-base-url: https://${domain}:443
+      entity-base-url: https://${domain}
       entity-id: ${domain}
     extended-metadata:
       idp-discovery-enabled: false    

--- a/src/test/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/censusfieldsvc/service/impl/LauncherServiceImplTest.java
@@ -36,7 +36,7 @@ public class LauncherServiceImplTest {
   private static final String SALT = "CENSUS";
   private static final String A_DUMMY_ENCRYPTED_PAYLOAD = "xasdsada";
   private static final String A_URL_RESULT =
-      "https://" + A_HOST + "/session?token=" + A_DUMMY_ENCRYPTED_PAYLOAD;
+      "https://" + A_HOST + "?token=" + A_DUMMY_ENCRYPTED_PAYLOAD;
 
   @Mock private KeyStore keyStoreEncryption;
 


### PR DESCRIPTION

Some adjustments required to ensure field-service runs with Gsuite SAML and can invoke the EQ endpoint:

- remove the 443 port from `entity-base-url` for deployed GSuite environments, but make sure it remains for local environments or for SAMLTEST.
- remove the /session suffix to launch path, since we need to route EQ launch via RHUI for the same workaround that we have in place for CCSvc .
- some logging in place to get early indication of rabbit credentials being valid or not.